### PR TITLE
Remove 10 subtitle limit

### DIFF
--- a/resources/lib/subtitle_downloader.py
+++ b/resources/lib/subtitle_downloader.py
@@ -132,11 +132,7 @@ class SubtitleDownloader:
 
     def list_subtitles(self):
         """TODO rewrite using new data. do not forget Series/Episodes"""
-        x = 0
         for subtitle in self.subtitles:
-            x += 1
-            if x > 10:
-                return
             attributes = subtitle["attributes"]
             language = convert_language(attributes["language"], True)
             log(__name__, attributes)


### PR DESCRIPTION
For some odd reason the implementation is limiting the number of returned subtitles to 10. For someone who has different languages configured for subtitle download (my case: english, portuguese and portuguese-brazilian) this pretty much makes it impossible to list subtitles in a different language than the 1st one.

Taking a look at the code this really doesn't add any load on the servers as the information of the whole list is already part of the response body.