### PR TITLE
Fix portuguese and brazilan flags not showing

### DIFF
--- a/resources/lib/data_collector.py
+++ b/resources/lib/data_collector.py
@@ -143,6 +143,13 @@ def convert_language(language, reverse=False):
     else:
         return xbmc.convertLanguage(language, xbmc_param)
 
+def get_flag(language_code):
+    language_list = {
+        "pt-pt": "pt",
+        "pt-br": "pb"
+    }
+    return language_list.get(language_code.lower(), language_code)
+
 
 def clean_feature_release_name(title, release, movie_name=""):
     if not title:

--- a/resources/lib/subtitle_downloader.py
+++ b/resources/lib/subtitle_downloader.py
@@ -10,7 +10,7 @@ import xbmcplugin
 import xbmcvfs
 
 from resources.lib.data_collector import get_language_data, get_media_data, get_file_path, convert_language, \
-    clean_feature_release_name
+    clean_feature_release_name, get_flag
 from resources.lib.exceptions import AuthenticationError, ConfigurationError, DownloadLimitExceeded, ProviderError, \
     ServiceUnavailable, TooManyRequests
 from resources.lib.file_operations import get_file_data
@@ -146,7 +146,7 @@ class SubtitleDownloader:
                                          label2=clean_name)
             list_item.setArt({
                 "icon": str(int(round(float(attributes["ratings"]) / 2))),
-                "thumb": attributes["language"]})
+                "thumb": get_flag(attributes["language"])})
             list_item.setProperty("sync", "true" if ("moviehash_match" in attributes and attributes["moviehash_match"]) else "false")
             list_item.setProperty("hearing_imp", "true" if attributes["hearing_impaired"] else "false")
             """TODO take care of multiple cds id&id or something"""


### PR DESCRIPTION
This fixes the Portuguese and Brazilian flags not showing in the interface. The country codes need to be mapped to "pt" (for portuguese) and "pb" (portuguese brazilian). The implementation is flexible enough to extend in the future with some other edge cases.