### PR TITLE
Allow addons to set path and size of the currently playing file

### DIFF
--- a/resources/lib/file_operations.py
+++ b/resources/lib/file_operations.py
@@ -2,7 +2,7 @@
 import os
 import struct
 
-import xbmcvfs
+import xbmcvfs, xbmc
 
 from resources.lib.utilities import log
 
@@ -12,6 +12,16 @@ def get_file_data(file_original_path):
 
 
     if file_original_path.find("http") > -1:
+        orig_path = xbmc.getInfoLabel('Window(10000).Property(videoinfo.current_path)')
+        orig_size = xbmc.getInfoLabel('Window(10000).Property(videoinfo.current_size)')
+        if orig_path:
+            orig_path = str(orig_path)
+            item["basename"] = os.path.basename(orig_path)
+            item["file_original_path"] = orig_path
+        if orig_size:
+            item["file_size"] = int(orig_size)
+            return item
+
         item["temp"] = True
 
     elif file_original_path.find("rar://") > -1:


### PR DESCRIPTION
When playing a file using an addon, such as Plex4Kodi or PM4K, the file path that the opensubtitles addon sees can be a stream URL, resulting in not-as-good query hinting when searching for subtitles.

Allow proper filename and size hinting by utilizing a global infoLabel in the "videoinfo" realm.

Addons can set it like this:
``` 
xbmcgui.Window(10000).setProperty('videoinfo.current_path', path)
xbmcgui.Window(10000).setProperty('videoinfo.current_size', str(size))
```

And the OpenSubtitles.com addon will read it if it's a stream URL.