### PR TITLE
Handle Chinese as a preferred language

### DIFF
--- a/resources/lib/data_collector.py
+++ b/resources/lib/data_collector.py
@@ -134,6 +134,7 @@ def convert_language(language, reverse=False):
         "English": "en",
         "Portuguese (Brazil)": "pt-br",
         "Portuguese": "pt-pt",
+        "Chinese": "zh-cn",
         "Chinese (simplified)": "zh-cn",
         "Chinese (traditional)": "zh-tw"}
 


### PR DESCRIPTION
Kodi passes a "preferredlanguage" param.
The current code handles "Chinese (simplified)" and "Chinese (traditional)" being passed, but a default Kodi installation seems to simply have an option for "Chinese". This PR handles that as zh-cn.

Fixes #25