### PR TITLE
Add trailing / to subdirectory folder

### DIFF
--- a/resources/lib/subtitle_downloader.py
+++ b/resources/lib/subtitle_downloader.py
@@ -122,9 +122,9 @@ class SubtitleDownloader:
 
         #subtitle_path = os.path.join(__temp__, f"{str(uuid.uuid4())}.{self.sub_format}")
         try:    # kodi > k19
-            dir_path = xbmcvfs.translatePath('special://temp/oss')       
+            dir_path = xbmcvfs.translatePath('special://temp/oss/')       
         except: # kodi < k19
-            dir_path = xbmc.translatePath('special://temp/oss')
+            dir_path = xbmc.translatePath('special://temp/oss/')
 
         # Kodi lang-code difference vs OS.com API langcodes return
         if self.params["language"].lower() == 'pt-pt': self.params["language"] = 'pt'


### PR DESCRIPTION
On my windows system with kodi 21.1, xbmcvfs.exists(dir_path) returns false if the trailing / is not there and it returns true if it is.