### PR TITLE
v1.0.14: stop logging credentials/tokens, auto-refresh expired sessions, download error-path fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ Search and download subtitles for movies and TV-Series from OpenSubtitles.com. S
 
 REST API implementation based on tomburke25 [python-opensubtitles-rest-api](https://github.com/tomburke25/python-opensubtitles-rest-api)                            
 
+v1.0.14 (2026-08-14)
+- security: stopped writing credentials, session tokens and API keys to the Kodi debug log
+- expired login sessions now refresh automatically instead of failing the download with "login failed"
+- fixed subtitle list failing to build when a subtitle has no rating
+- failed downloads no longer hand Kodi a subtitle file that does not exist
+- added a timeout to the filename-analysis request so playback can no longer hang on it
+
 v1.0.13 (2026-08-10)
 - TV episode searches now ask OpenSubtitles.com what the id supplied by the video add-on actually refers to, instead of assuming. One cached /features lookup says whether it is a show or an episode, and for an episode it also returns the show's id and the real season/episode numbers, so the search is built correctly whatever the add-on reported
 - fixed TV episode searches for video add-ons that report the show's IMDb/TMDb id rather than the episode's (Umbrella, POV), which 1.0.11 broke by always treating the player's id as an episode id. Add-ons disagree about what they put in that field and nothing local tells the two apart, so the add-on no longer guesses: it tries the show reading first (id + season/episode), then the episode reading (id on its own), and only falls back to a title search if neither matches. That also stops the title fallback from surfacing subtitles for a different show with a similar name (thanks peno64)

--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.subtitles.opensubtitles-com"
        name="OpenSubtitles.com"
-       version="1.0.13"
+       version="1.0.14"
        provider-name="amet, opensubtitles, juokelis, opensubtitlesdev">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
@@ -52,6 +52,13 @@
 		<description lang="zh_CN">多语种的电影及剧集字幕，每日更新千余条翻译好的字幕。免费下载，提供API接口，已拥有上百万的用户。</description>
 		<disclaimer lang="en_GB">Users need to provide OpenSubtitles.com username and password in add-on configuration. This is our new extension, old opensubtitles.org will not work on this, but the account can be easily imported on opensubtitles.com.</disclaimer>
 		<news>
+v1.0.14 (2026-08-14)
+- security: stopped writing credentials, session tokens and API keys to the Kodi debug log
+- expired login sessions now refresh automatically instead of failing the download with "login failed"
+- fixed subtitle list failing to build when a subtitle has no rating
+- failed downloads no longer hand Kodi a subtitle file that does not exist
+- added a timeout to the filename-analysis request so playback can no longer hang on it
+
 v1.0.13 (2026-08-10)
 - TV episode searches now ask OpenSubtitles.com whether the id the video add-on supplied is a show or an episode, instead of assuming
 - fixed TV episode searches for video add-ons that report the show's IMDb id rather than the episode's (Umbrella, POV), which 1.0.11 broke (thanks peno64)
@@ -116,6 +123,6 @@ v1.0.1 (2023-07-28)
 			<screenshot>resources/media/screenshot_2.jpg</screenshot>
 			<screenshot>resources/media/screenshot_3.jpg</screenshot>
 		</assets>
-		<source>https://github.com/opensubtitlesdev/service.subtitles.opensubtitles-com</source>
+		<source>https://github.com/opensubtitles-dev/service.subtitles.opensubtitles-com</source>
 	</extension>
 </addon>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,13 @@
 
+v1.0.14 (2026-08-14)
+- security: stopped writing credentials, session tokens and API keys to the Kodi debug log. The log previously included the password when only one credential was filled in, the full login response (which contains the session token), and the request headers (which contain the API key) - and debug logs are exactly what users share on forums when asking for help
+- expired login sessions now refresh automatically: the cached session token outlives its server-side validity, so downloads on long-running devices failed with "login failed" until the cache expired. A rejected token is now refreshed once and the download retried
+- fixed subtitle list failing to build when a subtitle has no rating
+- failed downloads no longer hand Kodi a path to a subtitle file that was never written
+- added a timeout to the filename-analysis (guessit) request so playback can no longer hang on it
+- User-Agent now reports the real add-on version instead of a hardcoded string
+- fixed addon.xml source link (wrong GitHub organisation name) and the settings section id
+
 v1.0.13 (2026-08-10)
 - TV episode searches now ask OpenSubtitles.com what the id supplied by the video add-on actually refers to, instead of assuming. One cached /features lookup says whether it is a show or an episode, and for an episode it also returns the show's id and the real season/episode numbers, so the search is built correctly whatever the add-on reported
 - fixed TV episode searches for video add-ons that report the show's IMDb/TMDb id rather than the episode's (Umbrella, POV), which 1.0.11 broke by always treating the player's id as an episode id. Add-ons disagree about what they put in that field and nothing local tells the two apart, so the add-on no longer guesses: it tries the show reading first (id + season/episode), then the episode reading (id on its own), and only falls back to a title search if neither matches. That also stops the title fallback from surfacing subtitles for a different show with a similar name (thanks peno64)

--- a/resources/lib/data_collector.py
+++ b/resources/lib/data_collector.py
@@ -339,7 +339,7 @@ def _call_guessit_api(filename):
         log(__name__, f"🔍 Calling guessit API for: {filename}")
         
         # Make the request
-        with urllib.request.urlopen(req) as response:
+        with urllib.request.urlopen(req, timeout=10) as response:
             if response.getcode() == 200:
                 data = json.loads(response.read().decode('utf-8'))
                 log(__name__, f"✅ Guessit API response: {data}")

--- a/resources/lib/osclient/provider.py
+++ b/resources/lib/osclient/provider.py
@@ -77,10 +77,11 @@ class OpenSubtitlesProvider:
         self.password = password
 
         if not self.username or not self.password:
-            logging(f"Username: {self.username}, Password: {self.password}")
+            logging(f"Credentials incomplete: username set: {bool(self.username)}, password set: {bool(self.password)}")
 
-
-        self.request_headers = {"Api-Key": self.api_key, "User-Agent": "Opensubtitles.com Kodi plugin v1.0.13" ,"Content-Type": CONTENT_TYPE, "Accept": CONTENT_TYPE}
+        self.request_headers = {"Api-Key": self.api_key,
+                                "User-Agent": f"Opensubtitles.com Kodi plugin v{__addon__.getAddonInfo('version')}",
+                                "Content-Type": CONTENT_TYPE, "Accept": CONTENT_TYPE}
 
         self.session = Session()
         self.session.headers = self.request_headers
@@ -96,20 +97,11 @@ class OpenSubtitlesProvider:
         login_body = {"username": self.username, "password": self.password}
 
         logging(f"Login attempt to: {login_url}")
-        logging(f"Login body: {{'username': '{self.username}', 'password': '***'}}")
 
         try:
             r = self.session.post(login_url, json=login_body, allow_redirects=False, timeout=REQUEST_TIMEOUT)
-            logging(f"Login response URL: {r.url}")
+            # Never log the login response headers or body: the body carries the JWT token.
             logging(f"Login response status: {r.status_code}")
-            logging(f"Login response headers: {dict(r.headers)}")
-
-            # Log response body for debugging
-            try:
-                response_text = r.text
-                logging(f"Login response body: {response_text}")
-            except:
-                logging("Failed to get response text")
 
             r.raise_for_status()
         except (ConnectionError, Timeout, ReadTimeout) as e:
@@ -122,12 +114,6 @@ class OpenSubtitlesProvider:
             status_code = e.response.status_code
             logging(f"HTTP error during login: {status_code}")
 
-            # Log the error response body for debugging
-            try:
-                error_response = e.response.text
-                logging(f"Login error response body: {error_response}")
-            except:
-                logging("Failed to get error response text")
 
             if status_code == 401:
                 raise AuthenticationError(f"Login failed: {e}")
@@ -142,11 +128,10 @@ class OpenSubtitlesProvider:
         else:
             try:
                 response_json = r.json()
-                logging(f"Login successful response JSON: {response_json}")
                 self.user_token = response_json["token"]
-                logging(f"Token extracted successfully")
-            except ValueError as e:
-                logging(f"Failed to parse login response JSON: {e}")
+                logging("Login successful, token received")
+            except (ValueError, KeyError) as e:
+                logging(f"Failed to parse login response JSON: {e!r}")
                 raise ValueError("Invalid JSON returned by provider")
 
     def get_user_info(self):
@@ -228,7 +213,9 @@ class OpenSubtitlesProvider:
 
     @user_token.setter
     def user_token(self, value):
-        self.cache.set(key="user_token", value=value)
+        # The API's JWT is valid for ~24h server-side; cache it for less than that so a
+        # long-running device re-logins instead of presenting an expired token.
+        self.cache.set(key="user_token", value=value, expires=60 * 60 * 20)
 
     def search_subtitles(self, query: Union[dict, OpenSubtitlesSubtitlesRequest]):
 
@@ -272,28 +259,17 @@ class OpenSubtitlesProvider:
                 logging(f"Cache check failed: {e}")
         # --- [END] Cache Check ---
 
-        # Check if we have a user token for authentication
-        current_token = self.user_token
-        logging(f"Current user token: {current_token[:20] if current_token else None}...")
+        logging(f"User token cached: {bool(self.user_token)}")
 
         try:
             # build query request
             subtitles_url = API_URL + API_SUBTITLES
-            logging(f"Search request URL: {subtitles_url}")
             logging(f"Search request params: {params}")
 
-            r = self.session.get(subtitles_url, params=params, timeout=30)
-            logging(f"Search response URL: {r.url}")
-            logging(f"Search response status: {r.status_code}")
-            logging(f"Search request headers sent: {dict(r.request.headers)}")
-            logging(f"Search response headers: {dict(r.headers)}")
-
-            # Log response body for debugging
-            try:
-                response_text = r.text
-                logging(f"Search response body: {response_text}")
-            except:
-                logging("Failed to get search response text")
+            # Never log request or response headers: they carry the Api-Key (and would
+            # carry the Authorization token) - users paste debug logs to public forums.
+            r = self.session.get(subtitles_url, params=params, timeout=REQUEST_TIMEOUT)
+            logging(f"Search response: {r.url} -> {r.status_code}")
 
             r.raise_for_status()
         except (ConnectionError, Timeout, ReadTimeout) as e:
@@ -303,11 +279,10 @@ class OpenSubtitlesProvider:
             status_code = e.response.status_code
             logging(f"HTTP error during subtitle search: {e}")
 
-            # Log the error response body for debugging
+            # Log the error response body for debugging (no secrets on this endpoint)
             try:
-                error_response = e.response.text
-                logging(f"Search error response body: {error_response}")
-            except:
+                logging(f"Search error response body: {e.response.text}")
+            except Exception:
                 logging("Failed to get search error response text")
 
             if status_code == 401:
@@ -378,9 +353,6 @@ class OpenSubtitlesProvider:
             logging("No cached token, but username or password is missing. Proceeding with free downloads.")
         if self.user_token == "":
             logging("Unable to obtain an authentication token.")
-            #raise ProviderError("Unable to obtain an authentication token")            
-            
-            logging(f"user token is {self.user_token}")
 
         params = query_to_params(query, "OpenSubtitlesDownloadRequest")
 
@@ -388,16 +360,31 @@ class OpenSubtitlesProvider:
 
         # build download request
         download_url = API_URL + API_DOWNLOAD
-        download_headers= {}
-        if not self.user_token==None:
-            download_headers = {"Authorization": "Bearer " + self.user_token}
-
         download_params = {"file_id": params["file_id"], "sub_format": "srt"}
 
+        def _post_download():
+            headers = {}
+            if self.user_token:
+                headers = {"Authorization": "Bearer " + self.user_token}
+            resp = self.session.post(download_url, headers=headers, json=download_params,
+                                     timeout=REQUEST_TIMEOUT)
+            logging(f"Download response: {resp.url} -> {resp.status_code}")
+            resp.raise_for_status()
+            return resp
+
         try:
-            r = self.session.post(download_url, headers=download_headers, json=download_params, timeout=REQUEST_TIMEOUT)
-            logging(r.url)
-            r.raise_for_status()
+            try:
+                r = _post_download()
+            except HTTPError as e:
+                # A cached token outlives its server-side validity (the JWT expires long
+                # before the cache entry does). On 401 with credentials available, refresh
+                # the token once and retry instead of surfacing "login failed".
+                if e.response is not None and e.response.status_code == 401 and self.username and self.password:
+                    logging("Cached token rejected (401), re-logging in and retrying download")
+                    self.login()
+                    r = _post_download()
+                else:
+                    raise
         except (ConnectionError, Timeout, ReadTimeout) as e:
             logging(f"Connection error during download: {e}")
             raise ServiceUnavailable(f"Connection error: {e!r}")
@@ -417,14 +404,24 @@ class OpenSubtitlesProvider:
         try:
             subtitle = r.json()
             download_link = subtitle["link"]
-        except ValueError:
+        except (ValueError, KeyError):
             raise ProviderError("Invalid JSON returned by provider")
         else:
-            res = self.session.get(download_link, timeout=REQUEST_TIMEOUT)
+            try:
+                res = self.session.get(download_link, timeout=REQUEST_TIMEOUT)
+                res.raise_for_status()
+            except HTTPError as e:
+                # exception reprs embed the URL; the download link is one-time and
+                # quota-bearing, so report only the status
+                raise ServiceUnavailable(
+                    f"Could not fetch subtitle file: HTTP {e.response.status_code if e.response is not None else 'error'}")
+            except (ConnectionError, Timeout, ReadTimeout):
+                raise ServiceUnavailable("Could not fetch subtitle file: connection error")
 
             subtitle["content"] = res.content
 
             if not subtitle["content"]:
-                logging(f"Could not download subtitle from {subtitle.download_link}")
+                # do not log the download link itself - it is a one-time quota-bearing URL
+                logging(f"Empty subtitle content for file_id {params['file_id']!r}")
 
         return subtitle

--- a/resources/lib/subtitle_downloader.py
+++ b/resources/lib/subtitle_downloader.py
@@ -188,7 +188,6 @@ class SubtitleDownloader:
         try:
             self.file = self.open_subtitles.download_subtitle(
                 {"file_id": self.params["id"], "sub_format": self.sub_format})
-            log(__name__, "XYXYXX download '%s' " % self.file)
         except AuthenticationError as e:
             error(__name__, 32003, e)
             valid = 0
@@ -196,7 +195,7 @@ class SubtitleDownloader:
             error(__name__, 32214, e)
             valid = 0
         except DownloadLimitExceeded as e:
-            log(__name__, f"XYXYXX limit excedded, username: {self.username}  {e}")
+            log(__name__, f"Download limit exceeded: {e}")
             if self.username=="":
                 error(__name__, 32006, e)
             else:
@@ -233,19 +232,18 @@ class SubtitleDownloader:
         if not xbmcvfs.exists(dir_path):  # lets create custom OSS sub directory if not exists
             xbmcvfs.mkdir(dir_path)
 
-        subtitle_path = os.path.join(dir_path, "{0}.{1}.{2}".format('TempSubtitle', self.params["language"], self.sub_format))   
-        
-        log(__name__, "XYXYXX download subtitle_path: {}".format(subtitle_path))
+        subtitle_path = os.path.join(dir_path, "{0}.{1}.{2}".format('TempSubtitle', self.params["language"], self.sub_format))
 
+        log(__name__, "download subtitle_path: {}".format(subtitle_path))
 
-        if (valid==1):
-            tmp_file = open(subtitle_path, "w" + "b")
-            tmp_file.write(self.file["content"])
-            tmp_file.close()
-        
+        # Only hand Kodi a subtitle entry when the download actually succeeded; the
+        # directory was wiped above, so on failure the path points at nothing.
+        if valid == 1 and self.file.get("content"):
+            with open(subtitle_path, "wb") as tmp_file:
+                tmp_file.write(self.file["content"])
 
-        list_item = xbmcgui.ListItem(label=subtitle_path)
-        xbmcplugin.addDirectoryItem(handle=self.handle, url=subtitle_path, listitem=list_item, isFolder=False)
+            list_item = xbmcgui.ListItem(label=subtitle_path)
+            xbmcplugin.addDirectoryItem(handle=self.handle, url=subtitle_path, listitem=list_item, isFolder=False)
 
         return
 
@@ -271,21 +269,13 @@ class SubtitleDownloader:
                 list_item = xbmcgui.ListItem(label=language,
                                              label2=clean_name)
                 list_item.setArt({
-                    "icon": str(int(round(float(attributes["ratings"]) / 2))),
+                    "icon": str(int(round(float(attributes.get("ratings") or 0) / 2))),
                     "thumb": get_flag(attributes["language"])})
-               # list_item.setArt({
-               #     "icon": str(int(round(float(attributes["ratings"]) / 2))),
-               #     "thumb": get_flag(language)})
-               
-                log(__name__, "XYXYXX download get_flag: language in url {}".format(get_flag(attributes["language"])))
 
-                
                 list_item.setProperty("sync", "true" if ("moviehash_match" in attributes and attributes["moviehash_match"]) else "false")
                 list_item.setProperty("hearing_imp", "true" if attributes["hearing_impaired"] else "false")
                 """TODO take care of multiple cds id&id or something"""
-                #url = f"plugin://{__scriptid__}/?action=download&id={attributes['files'][0]['file_id']}"
-                url = f"plugin://{__scriptid__}/?action=download&id={attributes['files'][0]['file_id']}&language={language}"    
-                log(__name__, "XYXYXX download list_subtitles: language in url {url}")
+                url = f"plugin://{__scriptid__}/?action=download&id={attributes['files'][0]['file_id']}&language={language}"
 
                 xbmcplugin.addDirectoryItem(handle=self.handle, url=url, listitem=list_item, isFolder=False)
         xbmcplugin.endOfDirectory(self.handle)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <settings version="1">
-    <section id="service.subtitles.opensubtitles">
+    <section id="service.subtitles.opensubtitles-com">
         <category id="user" label="32101">
             <group id="1">
                 <setting id="OSuser" type="string" label="32201">


### PR DESCRIPTION
## v1.0.14 — security and reliability hygiene

This is the first of a planned series of maintenance PRs (next up: replacing the dead Travis pipeline with GitHub Actions so releases reach the official Kodi repo again — users there are still on 1.0.9).

### Security — stop writing secrets to the Kodi debug log

Users share full debug logs on public forums when asking for help, and a failed login is exactly the scenario where these lines fired. Removed from the log:

- the **password**, printed in plaintext when only one credential was filled in (`provider.py`, present since v1.0.4)
- the full **`/login` response body**, which carries the JWT session token
- the sent **request headers**, which carry the `Api-Key` (and would carry `Authorization`)
- the cached **session token** (full and 20-char-prefix variants)
- the **username** on login and quota-error paths
- the **one-time download link** (quota-bearing URL) — also kept out of exception messages shown in error dialogs

All credential-adjacent log lines now emit booleans or fixed strings.

### Reliability

- **Expired sessions refresh automatically**: the cached token outlived its ~24h server-side validity (cache default was 7 days), so downloads on long-running devices failed with "login failed" for days. Token now cached for 20h, and a rejected token triggers one re-login + retry.
- **Download error paths**: failed downloads no longer hand Kodi a path to a file that was never written (or an empty one); the subtitle-file fetch handles HTTP errors and connection loss instead of writing an HTML error page as the subtitle or crashing; missing `link` in the API response no longer escapes as an uncaught `KeyError`; fixed the `subtitle.download_link` `AttributeError`.
- **Subtitle list** no longer fails when a subtitle has no rating.
- **guessit request** now has a timeout so playback cannot hang on it.

### Metadata

- `addon.xml`: version 1.0.14 + news; `<source>` fixed to the real org (`opensubtitles-dev`, was `opensubtitlesdev`)
- `settings.xml`: section id now matches the add-on id (values are keyed by setting id, existing user configs unaffected)
- User-Agent reports the real add-on version instead of a hardcoded string
- changelog.txt / README.md entries

### Deliberately out of scope (follow-up PRs)

- CI / kodi-addon-checker / release automation (Travis replacement)
- `reuselanguageinvoker` (requires restructuring the module-level entry point first)
- pagination, format/FPS options, notification-style errors

### Testing

`py_compile` clean on all touched modules; both XMLs parse. Exception-flow of the 401-retry verified for all five paths (retry-401, retry-406, retry-OK, non-401 first try, no-credentials). Manual Kodi smoke test recommended before tagging: fresh install, wrong creds, valid creds, expired-token download, quota exceeded.
